### PR TITLE
Add Token-2022 and Anchor discriminator helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,3 +86,25 @@ This crate provides fundamental Solana blockchain primitives for constructing an
    - **Required**: Ensure all tests pass with `cargo test`
    - **Best Practice**: Use `just lint` and `just test` shortcuts when available
    - **Reason**: Maintains consistent code quality and prevents CI failures
+
+## Version Control: Jujutsu (jj)
+
+This repo uses [Jujutsu](https://jj-vcs.github.io/jj/) as the primary VCS, co-located with Git (the `.git` directory still exists, so `git` commands also work — but prefer `jj`).
+
+### Common commands
+
+- `jj st` — show working-copy status
+- `jj log` / `jj log -r '..@'` — show recent changes
+- `jj diff` — show working-copy diff
+- `jj new` — start a new change on top of `@`
+- `jj describe -m "..."` — set or amend the current change's message
+- `jj commit -m "..."` — describe the current change and start a new empty one
+- `jj squash` — fold the current change into its parent
+- `jj git push` — push changes to the Git remote
+- `jj git fetch` — pull updates from the Git remote
+
+### Workflow notes
+
+- jj has no staging area: every working-copy edit is part of the current change automatically.
+- Amending is cheap and non-destructive — `jj describe`/`jj squash` rewrite the current change, and jj keeps the old version in the op log (`jj op log` / `jj op restore` to undo).
+- For PRs, push the change with `jj git push -c @` (creates a Git branch from the current change) or push an existing branch with `jj git push --branch <name>`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "solana-primitives"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["solana-primitives"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 license = "Apache-2.0"
 readme = "README.md"

--- a/solana-primitives/src/builder/transaction.rs
+++ b/solana-primitives/src/builder/transaction.rs
@@ -319,16 +319,15 @@ impl TransactionBuilder {
         };
 
         let mut virtual_index_map: HashMap<Pubkey, u8> = HashMap::new();
-        let mut next_virtual_index = account_keys.len();
-        for (pubkey, _) in lookup_writable
-            .iter()
-            .flat_map(|entries| entries.iter())
-            .chain(lookup_readonly.iter().flat_map(|entries| entries.iter()))
-        {
+        for (next_virtual_index, (pubkey, _)) in (account_keys.len()..).zip(
+            lookup_writable
+                .iter()
+                .flat_map(|entries| entries.iter())
+                .chain(lookup_readonly.iter().flat_map(|entries| entries.iter())),
+        ) {
             let virtual_index =
                 u8::try_from(next_virtual_index).map_err(|_| SolanaError::InvalidMessage)?;
             virtual_index_map.insert(*pubkey, virtual_index);
-            next_virtual_index += 1;
         }
 
         let address_table_lookups: Vec<MessageAddressTableLookup> = address_lookup_tables

--- a/solana-primitives/src/instructions/anchor.rs
+++ b/solana-primitives/src/instructions/anchor.rs
@@ -2,7 +2,9 @@ use sha2::{Digest, Sha256};
 
 fn namespaced_discriminator(namespace: &str, name: &str) -> [u8; 8] {
     let mut hasher = Sha256::new();
-    hasher.update(format!("{namespace}:{name}").as_bytes());
+    hasher.update(namespace.as_bytes());
+    hasher.update(b":");
+    hasher.update(name.as_bytes());
     let hash = hasher.finalize();
     let mut data = [0u8; 8];
     data.copy_from_slice(&hash[..8]);

--- a/solana-primitives/src/instructions/anchor.rs
+++ b/solana-primitives/src/instructions/anchor.rs
@@ -1,0 +1,71 @@
+use sha2::{Digest, Sha256};
+
+fn namespaced_discriminator(namespace: &str, name: &str) -> [u8; 8] {
+    let mut hasher = Sha256::new();
+    hasher.update(format!("{namespace}:{name}").as_bytes());
+    let hash = hasher.finalize();
+    let mut data = [0u8; 8];
+    data.copy_from_slice(&hash[..8]);
+    data
+}
+
+/// Return the 8-byte Anchor instruction discriminator for a global instruction name.
+///
+/// This is the prefix Anchor prepends to instruction data for entrypoints declared
+/// inside `#[program]`.
+pub fn global_discriminator(name: &str) -> [u8; 8] {
+    namespaced_discriminator("global", name)
+}
+
+/// Return the 8-byte Anchor account discriminator for an account type name.
+///
+/// This is the prefix Anchor writes at the start of every account's data for types
+/// declared with `#[account]`. Use it to identify or verify account types when parsing.
+pub fn account_discriminator(name: &str) -> [u8; 8] {
+    namespaced_discriminator("account", name)
+}
+
+/// Return the 8-byte Anchor event discriminator for an event type name.
+///
+/// This is the prefix Anchor writes at the start of an event payload emitted via
+/// `emit!` for types declared with `#[event]`. Use it to identify events in program logs.
+pub fn event_discriminator(name: &str) -> [u8; 8] {
+    namespaced_discriminator("event", name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_global_discriminator() {
+        assert_eq!(
+            global_discriminator("init_order"),
+            [0x20, 0x4c, 0x29, 0x0c, 0x27, 0xa2, 0x84, 0xdb]
+        );
+    }
+
+    #[test]
+    fn test_account_discriminator() {
+        assert_eq!(
+            account_discriminator("Order"),
+            [0x86, 0xad, 0xdf, 0xb9, 0x4d, 0x56, 0x1c, 0x33]
+        );
+    }
+
+    #[test]
+    fn test_event_discriminator() {
+        assert_eq!(
+            event_discriminator("OrderPlaced"),
+            [0x60, 0x82, 0xcc, 0xea, 0xa9, 0xdb, 0xd8, 0xe3]
+        );
+    }
+
+    #[test]
+    fn test_namespaces_differ_for_same_name() {
+        let name = "Foo";
+        assert_ne!(global_discriminator(name), account_discriminator(name));
+        assert_ne!(global_discriminator(name), event_discriminator(name));
+        assert_ne!(account_discriminator(name), event_discriminator(name));
+    }
+}

--- a/solana-primitives/src/instructions/associated_token.rs
+++ b/solana-primitives/src/instructions/associated_token.rs
@@ -1,5 +1,5 @@
 use crate::instructions::program_ids::{
-    ASSOCIATED_TOKEN_PROGRAM_ID, SYSTEM_PROGRAM_ID, SYSVAR_RENT_ID, TOKEN_PROGRAM_ID,
+    associated_token_program, rent_sysvar, system_program, token_program,
 };
 use crate::types::{AccountMeta, Instruction, Pubkey, find_program_address};
 
@@ -14,7 +14,7 @@ pub fn create_associated_token_account(
     wallet_address: &Pubkey,
     token_mint_address: &Pubkey,
 ) -> Instruction {
-    let token_program_id = Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap();
+    let token_program_id = token_program();
     create_associated_token_account_with_program_id(
         payer,
         wallet_address,
@@ -121,7 +121,7 @@ fn create_associated_token_account_instruction(
         },
         // System program
         AccountMeta {
-            pubkey: Pubkey::from_base58(SYSTEM_PROGRAM_ID).unwrap(),
+            pubkey: system_program(),
             is_signer: false,
             is_writable: false,
         },
@@ -133,14 +133,14 @@ fn create_associated_token_account_instruction(
         },
         // Rent sysvar
         AccountMeta {
-            pubkey: Pubkey::from_base58(SYSVAR_RENT_ID).unwrap(),
+            pubkey: rent_sysvar(),
             is_signer: false,
             is_writable: false,
         },
     ];
 
     Instruction {
-        program_id: Pubkey::from_base58(ASSOCIATED_TOKEN_PROGRAM_ID).unwrap(),
+        program_id: associated_token_program(),
         accounts: account_metas,
         data,
     }
@@ -151,7 +151,7 @@ pub fn get_associated_token_address(
     wallet_address: &Pubkey,
     token_mint_address: &Pubkey,
 ) -> Pubkey {
-    let token_program_id = Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap();
+    let token_program_id = token_program();
     get_associated_token_address_with_program_id(
         wallet_address,
         token_mint_address,
@@ -165,7 +165,7 @@ pub fn get_associated_token_address_with_program_id(
     token_mint_address: &Pubkey,
     token_program_id: &Pubkey,
 ) -> Pubkey {
-    let associated_token_program_id = Pubkey::from_base58(ASSOCIATED_TOKEN_PROGRAM_ID).unwrap();
+    let associated_token_program_id = associated_token_program();
 
     let seeds: [&[u8]; 3] = [
         wallet_address.as_bytes(),
@@ -182,7 +182,10 @@ pub fn get_associated_token_address_with_program_id(
 mod tests {
     use super::*;
     use crate::Pubkey;
-    use crate::instructions::program_ids::{SYSVAR_RENT_ID, TOKEN_2022_PROGRAM_ID};
+    use crate::instructions::program_ids::{
+        ASSOCIATED_TOKEN_PROGRAM_ID, SYSTEM_PROGRAM_ID, SYSVAR_RENT_ID, TOKEN_2022_PROGRAM_ID,
+        TOKEN_PROGRAM_ID,
+    };
 
     fn mint_pubkey() -> Pubkey {
         Pubkey::from_base58("7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z").unwrap()

--- a/solana-primitives/src/instructions/associated_token.rs
+++ b/solana-primitives/src/instructions/associated_token.rs
@@ -1,16 +1,99 @@
 use crate::instructions::program_ids::{
-    ASSOCIATED_TOKEN_PROGRAM_ID, SYSTEM_PROGRAM_ID, TOKEN_PROGRAM_ID,
+    ASSOCIATED_TOKEN_PROGRAM_ID, SYSTEM_PROGRAM_ID, SYSVAR_RENT_ID, TOKEN_PROGRAM_ID,
 };
 use crate::types::{AccountMeta, Instruction, Pubkey, find_program_address};
 
-/// Create an associated token account instruction
+/// Discriminator for the `Create` variant of the AssociatedTokenAccount program.
+const CREATE_DISCRIMINATOR: &[u8] = &[];
+/// Discriminator for the `CreateIdempotent` variant of the AssociatedTokenAccount program.
+const IDEMPOTENT_DISCRIMINATOR: &[u8] = &[1];
+
+/// Create an associated token account instruction (defaults to the SPL Token program)
 pub fn create_associated_token_account(
     payer: &Pubkey,
     wallet_address: &Pubkey,
     token_mint_address: &Pubkey,
 ) -> Instruction {
-    let associated_token_address = get_associated_token_address(wallet_address, token_mint_address);
+    let token_program_id = Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap();
+    create_associated_token_account_with_program_id(
+        payer,
+        wallet_address,
+        token_mint_address,
+        &token_program_id,
+    )
+}
 
+/// Create an associated token account instruction using the provided token program
+pub fn create_associated_token_account_with_program_id(
+    payer: &Pubkey,
+    wallet_address: &Pubkey,
+    token_mint_address: &Pubkey,
+    token_program_id: &Pubkey,
+) -> Instruction {
+    let associated_token_address = get_associated_token_address_with_program_id(
+        wallet_address,
+        token_mint_address,
+        token_program_id,
+    );
+
+    create_associated_token_account_instruction(
+        payer,
+        &associated_token_address,
+        wallet_address,
+        token_mint_address,
+        token_program_id,
+        CREATE_DISCRIMINATOR.to_vec(),
+    )
+}
+
+/// Create an associated token account idempotent instruction
+pub fn create_associated_token_account_idempotent(
+    payer: &Pubkey,
+    wallet_address: &Pubkey,
+    token_mint_address: &Pubkey,
+    token_program_id: &Pubkey,
+) -> Instruction {
+    let associated_token_address = get_associated_token_address_with_program_id(
+        wallet_address,
+        token_mint_address,
+        token_program_id,
+    );
+
+    create_associated_token_account_idempotent_with_address(
+        payer,
+        &associated_token_address,
+        wallet_address,
+        token_mint_address,
+        token_program_id,
+    )
+}
+
+/// Create an associated token account idempotent instruction with an explicit associated token account address
+pub fn create_associated_token_account_idempotent_with_address(
+    payer: &Pubkey,
+    associated_token_address: &Pubkey,
+    wallet_address: &Pubkey,
+    token_mint_address: &Pubkey,
+    token_program_id: &Pubkey,
+) -> Instruction {
+    create_associated_token_account_instruction(
+        payer,
+        associated_token_address,
+        wallet_address,
+        token_mint_address,
+        token_program_id,
+        IDEMPOTENT_DISCRIMINATOR.to_vec(),
+    )
+}
+
+fn create_associated_token_account_instruction(
+    payer: &Pubkey,
+    associated_token_address: &Pubkey,
+    wallet_address: &Pubkey,
+    token_mint_address: &Pubkey,
+    token_program_id: &Pubkey,
+    data: Vec<u8>,
+) -> Instruction {
     let account_metas = vec![
         // Funding account
         AccountMeta {
@@ -20,7 +103,7 @@ pub fn create_associated_token_account(
         },
         // Associated token account
         AccountMeta {
-            pubkey: associated_token_address,
+            pubkey: *associated_token_address,
             is_signer: false,
             is_writable: true,
         },
@@ -44,13 +127,13 @@ pub fn create_associated_token_account(
         },
         // Token program
         AccountMeta {
-            pubkey: Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap(),
+            pubkey: *token_program_id,
             is_signer: false,
             is_writable: false,
         },
         // Rent sysvar
         AccountMeta {
-            pubkey: Pubkey::from_base58("SysvarRent111111111111111111111111111111111").unwrap(),
+            pubkey: Pubkey::from_base58(SYSVAR_RENT_ID).unwrap(),
             is_signer: false,
             is_writable: false,
         },
@@ -59,7 +142,7 @@ pub fn create_associated_token_account(
     Instruction {
         program_id: Pubkey::from_base58(ASSOCIATED_TOKEN_PROGRAM_ID).unwrap(),
         accounts: account_metas,
-        data: vec![],
+        data,
     }
 }
 
@@ -69,6 +152,19 @@ pub fn get_associated_token_address(
     token_mint_address: &Pubkey,
 ) -> Pubkey {
     let token_program_id = Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap();
+    get_associated_token_address_with_program_id(
+        wallet_address,
+        token_mint_address,
+        &token_program_id,
+    )
+}
+
+/// Derive the associated token account address for a wallet address, token mint, and token program
+pub fn get_associated_token_address_with_program_id(
+    wallet_address: &Pubkey,
+    token_mint_address: &Pubkey,
+    token_program_id: &Pubkey,
+) -> Pubkey {
     let associated_token_program_id = Pubkey::from_base58(ASSOCIATED_TOKEN_PROGRAM_ID).unwrap();
 
     let seeds: [&[u8]; 3] = [
@@ -86,6 +182,7 @@ pub fn get_associated_token_address(
 mod tests {
     use super::*;
     use crate::Pubkey;
+    use crate::instructions::program_ids::{SYSVAR_RENT_ID, TOKEN_2022_PROGRAM_ID};
 
     fn mint_pubkey() -> Pubkey {
         Pubkey::from_base58("7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z").unwrap()
@@ -157,12 +254,121 @@ mod tests {
         // Rent sysvar
         assert_eq!(
             instruction.accounts[6].pubkey,
-            Pubkey::from_base58("SysvarRent111111111111111111111111111111111").unwrap()
+            Pubkey::from_base58(SYSVAR_RENT_ID).unwrap()
         );
         assert!(!instruction.accounts[6].is_signer);
         assert!(!instruction.accounts[6].is_writable);
 
         // Check data - should be empty
         assert_eq!(instruction.data, Vec::<u8>::new());
+    }
+
+    #[test]
+    fn test_create_associated_token_account_with_program_id() {
+        let payer = payer_pubkey();
+        let wallet_address = owner_pubkey();
+        let token_mint_address = mint_pubkey();
+        let token_program_id = Pubkey::from_base58(TOKEN_2022_PROGRAM_ID).unwrap();
+
+        let instruction = create_associated_token_account_with_program_id(
+            &payer,
+            &wallet_address,
+            &token_mint_address,
+            &token_program_id,
+        );
+
+        assert_eq!(
+            instruction.program_id,
+            Pubkey::from_base58(ASSOCIATED_TOKEN_PROGRAM_ID).unwrap()
+        );
+        assert_eq!(instruction.accounts.len(), 7);
+
+        let associated_token_address = get_associated_token_address_with_program_id(
+            &wallet_address,
+            &token_mint_address,
+            &token_program_id,
+        );
+        assert_eq!(instruction.accounts[1].pubkey, associated_token_address);
+        assert_eq!(instruction.accounts[5].pubkey, token_program_id);
+        assert_eq!(
+            instruction.accounts[6].pubkey,
+            Pubkey::from_base58(SYSVAR_RENT_ID).unwrap()
+        );
+        assert!(instruction.data.is_empty());
+    }
+
+    #[test]
+    fn test_create_associated_token_account_idempotent() {
+        let payer = payer_pubkey();
+        let wallet_address = owner_pubkey();
+        let token_mint_address = mint_pubkey();
+        let token_program_id = Pubkey::from_base58(TOKEN_2022_PROGRAM_ID).unwrap();
+
+        let instruction = create_associated_token_account_idempotent(
+            &payer,
+            &wallet_address,
+            &token_mint_address,
+            &token_program_id,
+        );
+
+        assert_eq!(
+            instruction.program_id,
+            Pubkey::from_base58(ASSOCIATED_TOKEN_PROGRAM_ID).unwrap()
+        );
+        assert_eq!(instruction.accounts.len(), 7);
+        assert_eq!(instruction.accounts[0].pubkey, payer);
+        assert!(instruction.accounts[0].is_signer);
+        assert!(instruction.accounts[0].is_writable);
+
+        let associated_token_address = get_associated_token_address_with_program_id(
+            &wallet_address,
+            &token_mint_address,
+            &token_program_id,
+        );
+        assert_eq!(instruction.accounts[1].pubkey, associated_token_address);
+        assert!(!instruction.accounts[1].is_signer);
+        assert!(instruction.accounts[1].is_writable);
+
+        assert_eq!(instruction.accounts[2].pubkey, wallet_address);
+        assert!(!instruction.accounts[2].is_signer);
+        assert!(!instruction.accounts[2].is_writable);
+
+        assert_eq!(instruction.accounts[3].pubkey, token_mint_address);
+        assert!(!instruction.accounts[3].is_signer);
+        assert!(!instruction.accounts[3].is_writable);
+
+        assert_eq!(
+            instruction.accounts[4].pubkey,
+            Pubkey::from_base58(SYSTEM_PROGRAM_ID).unwrap()
+        );
+        assert!(!instruction.accounts[4].is_signer);
+        assert!(!instruction.accounts[4].is_writable);
+
+        assert_eq!(instruction.accounts[5].pubkey, token_program_id);
+        assert!(!instruction.accounts[5].is_signer);
+        assert!(!instruction.accounts[5].is_writable);
+
+        assert_eq!(
+            instruction.accounts[6].pubkey,
+            Pubkey::from_base58(SYSVAR_RENT_ID).unwrap()
+        );
+        assert!(!instruction.accounts[6].is_signer);
+        assert!(!instruction.accounts[6].is_writable);
+
+        assert_eq!(instruction.data, vec![1]);
+
+        let explicit_instruction = create_associated_token_account_idempotent_with_address(
+            &payer,
+            &associated_token_address,
+            &wallet_address,
+            &token_mint_address,
+            &token_program_id,
+        );
+        assert_eq!(
+            explicit_instruction.accounts[1].pubkey,
+            associated_token_address
+        );
+        assert_eq!(explicit_instruction.accounts[5].pubkey, token_program_id);
+        assert_eq!(explicit_instruction.data, vec![1]);
     }
 }

--- a/solana-primitives/src/instructions/mod.rs
+++ b/solana-primitives/src/instructions/mod.rs
@@ -1,4 +1,5 @@
 // Re-export instruction modules
+pub mod anchor;
 pub mod associated_token;
 pub mod compute_budget;
 pub mod memo;
@@ -29,6 +30,9 @@ pub mod program_ids {
 
     /// Compute Budget program ID
     pub const COMPUTE_BUDGET_PROGRAM_ID: &str = "ComputeBudget111111111111111111111111111111";
+
+    /// Rent sysvar ID
+    pub const SYSVAR_RENT_ID: &str = "SysvarRent111111111111111111111111111111111";
 
     /// Helper function to get System program Pubkey
     pub fn system_program() -> Pubkey {
@@ -63,5 +67,10 @@ pub mod program_ids {
     /// Helper function to get Compute Budget program Pubkey
     pub fn compute_budget_program() -> Pubkey {
         Pubkey::from_base58(COMPUTE_BUDGET_PROGRAM_ID).unwrap()
+    }
+
+    /// Helper function to get Rent sysvar Pubkey
+    pub fn rent_sysvar() -> Pubkey {
+        Pubkey::from_base58(SYSVAR_RENT_ID).unwrap()
     }
 }

--- a/solana-primitives/src/instructions/token.rs
+++ b/solana-primitives/src/instructions/token.rs
@@ -1,4 +1,4 @@
-use crate::instructions::program_ids::{SYSVAR_RENT_ID, TOKEN_PROGRAM_ID};
+use crate::instructions::program_ids::{rent_sysvar, token_program};
 use crate::types::{AccountMeta, Instruction, Pubkey};
 
 /// Token program instruction types
@@ -250,10 +250,6 @@ impl From<&AuthorityType> for u8 {
     }
 }
 
-fn default_token_program_id() -> Pubkey {
-    Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap()
-}
-
 /// Create and initialize a token mint (defaults to the SPL Token program)
 pub fn initialize_mint(
     mint: &Pubkey,
@@ -266,7 +262,7 @@ pub fn initialize_mint(
         mint_authority,
         freeze_authority,
         decimals,
-        &default_token_program_id(),
+        &token_program(),
     )
 }
 
@@ -285,7 +281,7 @@ pub fn initialize_mint_with_program_id(
             is_writable: true,
         },
         AccountMeta {
-            pubkey: Pubkey::from_base58(SYSVAR_RENT_ID).unwrap(),
+            pubkey: rent_sysvar(),
             is_signer: false,
             is_writable: false,
         },
@@ -306,7 +302,7 @@ pub fn initialize_mint_with_program_id(
 
 /// Create and initialize a token account (defaults to the SPL Token program)
 pub fn initialize_account(account: &Pubkey, mint: &Pubkey, owner: &Pubkey) -> Instruction {
-    initialize_account_with_program_id(account, mint, owner, &default_token_program_id())
+    initialize_account_with_program_id(account, mint, owner, &token_program())
 }
 
 /// Create and initialize a token account using the provided token program
@@ -333,7 +329,7 @@ pub fn initialize_account_with_program_id(
             is_writable: false,
         },
         AccountMeta {
-            pubkey: Pubkey::from_base58(SYSVAR_RENT_ID).unwrap(),
+            pubkey: rent_sysvar(),
             is_signer: false,
             is_writable: false,
         },
@@ -350,13 +346,7 @@ pub fn initialize_account_with_program_id(
 
 /// Transfer tokens from one account to another (defaults to the SPL Token program)
 pub fn transfer(source: &Pubkey, destination: &Pubkey, owner: &Pubkey, amount: u64) -> Instruction {
-    transfer_with_program_id(
-        source,
-        destination,
-        owner,
-        amount,
-        &default_token_program_id(),
-    )
+    transfer_with_program_id(source, destination, owner, amount, &token_program())
 }
 
 /// Transfer tokens from one account to another using the provided token program
@@ -401,13 +391,7 @@ pub fn mint_to(
     authority: &Pubkey,
     amount: u64,
 ) -> Instruction {
-    mint_to_with_program_id(
-        mint,
-        destination,
-        authority,
-        amount,
-        &default_token_program_id(),
-    )
+    mint_to_with_program_id(mint, destination, authority, amount, &token_program())
 }
 
 /// Mint tokens to an account using the provided token program
@@ -447,13 +431,7 @@ pub fn mint_to_with_program_id(
 
 /// Burn tokens from an account (defaults to the SPL Token program)
 pub fn burn(account: &Pubkey, mint: &Pubkey, authority: &Pubkey, amount: u64) -> Instruction {
-    burn_with_program_id(
-        account,
-        mint,
-        authority,
-        amount,
-        &default_token_program_id(),
-    )
+    burn_with_program_id(account, mint, authority, amount, &token_program())
 }
 
 /// Burn tokens from an account using the provided token program
@@ -493,7 +471,7 @@ pub fn burn_with_program_id(
 
 /// Close a token account (defaults to the SPL Token program)
 pub fn close_account(account: &Pubkey, destination: &Pubkey, owner: &Pubkey) -> Instruction {
-    close_account_with_program_id(account, destination, owner, &default_token_program_id())
+    close_account_with_program_id(account, destination, owner, &token_program())
 }
 
 /// Close a token account using the provided token program
@@ -546,7 +524,7 @@ pub fn transfer_checked(
         owner,
         amount,
         decimals,
-        &default_token_program_id(),
+        &token_program(),
     )
 }
 
@@ -606,7 +584,7 @@ pub fn mint_to_checked(
         authority,
         amount,
         decimals,
-        &default_token_program_id(),
+        &token_program(),
     )
 }
 
@@ -654,14 +632,7 @@ pub fn burn_checked(
     amount: u64,
     decimals: u8,
 ) -> Instruction {
-    burn_checked_with_program_id(
-        account,
-        mint,
-        authority,
-        amount,
-        decimals,
-        &default_token_program_id(),
-    )
+    burn_checked_with_program_id(account, mint, authority, amount, decimals, &token_program())
 }
 
 /// Burn tokens from an account, asserting the token mint and decimals, using the provided token program
@@ -702,7 +673,7 @@ pub fn burn_checked_with_program_id(
 
 /// Sync native instruction (defaults to the SPL Token program)
 pub fn sync_native(account: &Pubkey) -> Instruction {
-    sync_native_with_program_id(account, &default_token_program_id())
+    sync_native_with_program_id(account, &token_program())
 }
 
 /// Sync native instruction using the provided token program
@@ -726,7 +697,9 @@ pub fn sync_native_with_program_id(account: &Pubkey, token_program_id: &Pubkey) 
 mod tests {
     use super::*;
     use crate::Pubkey;
-    use crate::instructions::program_ids::TOKEN_2022_PROGRAM_ID;
+    use crate::instructions::program_ids::{
+        SYSVAR_RENT_ID, TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID,
+    };
 
     // Use the same public keys as in the JavaScript test file
     fn mint_pubkey() -> Pubkey {

--- a/solana-primitives/src/instructions/token.rs
+++ b/solana-primitives/src/instructions/token.rs
@@ -1,4 +1,4 @@
-use crate::instructions::program_ids::TOKEN_PROGRAM_ID;
+use crate::instructions::program_ids::{SYSVAR_RENT_ID, TOKEN_PROGRAM_ID};
 use crate::types::{AccountMeta, Instruction, Pubkey};
 
 /// Token program instruction types
@@ -250,12 +250,33 @@ impl From<&AuthorityType> for u8 {
     }
 }
 
-/// Create and initialize a token mint
+fn default_token_program_id() -> Pubkey {
+    Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap()
+}
+
+/// Create and initialize a token mint (defaults to the SPL Token program)
 pub fn initialize_mint(
     mint: &Pubkey,
     mint_authority: &Pubkey,
     freeze_authority: Option<&Pubkey>,
     decimals: u8,
+) -> Instruction {
+    initialize_mint_with_program_id(
+        mint,
+        mint_authority,
+        freeze_authority,
+        decimals,
+        &default_token_program_id(),
+    )
+}
+
+/// Create and initialize a token mint using the provided token program
+pub fn initialize_mint_with_program_id(
+    mint: &Pubkey,
+    mint_authority: &Pubkey,
+    freeze_authority: Option<&Pubkey>,
+    decimals: u8,
+    token_program_id: &Pubkey,
 ) -> Instruction {
     let account_metas = vec![
         AccountMeta {
@@ -264,7 +285,7 @@ pub fn initialize_mint(
             is_writable: true,
         },
         AccountMeta {
-            pubkey: Pubkey::from_base58("SysvarRent111111111111111111111111111111111").unwrap(),
+            pubkey: Pubkey::from_base58(SYSVAR_RENT_ID).unwrap(),
             is_signer: false,
             is_writable: false,
         },
@@ -277,14 +298,24 @@ pub fn initialize_mint(
     };
 
     Instruction {
-        program_id: Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap(),
+        program_id: *token_program_id,
         accounts: account_metas,
         data: instruction.serialize(),
     }
 }
 
-/// Create and initialize a token account
+/// Create and initialize a token account (defaults to the SPL Token program)
 pub fn initialize_account(account: &Pubkey, mint: &Pubkey, owner: &Pubkey) -> Instruction {
+    initialize_account_with_program_id(account, mint, owner, &default_token_program_id())
+}
+
+/// Create and initialize a token account using the provided token program
+pub fn initialize_account_with_program_id(
+    account: &Pubkey,
+    mint: &Pubkey,
+    owner: &Pubkey,
+    token_program_id: &Pubkey,
+) -> Instruction {
     let account_metas = vec![
         AccountMeta {
             pubkey: *account,
@@ -302,7 +333,7 @@ pub fn initialize_account(account: &Pubkey, mint: &Pubkey, owner: &Pubkey) -> In
             is_writable: false,
         },
         AccountMeta {
-            pubkey: Pubkey::from_base58("SysvarRent111111111111111111111111111111111").unwrap(),
+            pubkey: Pubkey::from_base58(SYSVAR_RENT_ID).unwrap(),
             is_signer: false,
             is_writable: false,
         },
@@ -311,14 +342,31 @@ pub fn initialize_account(account: &Pubkey, mint: &Pubkey, owner: &Pubkey) -> In
     let instruction = TokenInstruction::InitializeAccount;
 
     Instruction {
-        program_id: Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap(),
+        program_id: *token_program_id,
         accounts: account_metas,
         data: instruction.serialize(),
     }
 }
 
-/// Transfer tokens from one account to another
+/// Transfer tokens from one account to another (defaults to the SPL Token program)
 pub fn transfer(source: &Pubkey, destination: &Pubkey, owner: &Pubkey, amount: u64) -> Instruction {
+    transfer_with_program_id(
+        source,
+        destination,
+        owner,
+        amount,
+        &default_token_program_id(),
+    )
+}
+
+/// Transfer tokens from one account to another using the provided token program
+pub fn transfer_with_program_id(
+    source: &Pubkey,
+    destination: &Pubkey,
+    owner: &Pubkey,
+    amount: u64,
+    token_program_id: &Pubkey,
+) -> Instruction {
     let account_metas = vec![
         AccountMeta {
             pubkey: *source,
@@ -340,18 +388,35 @@ pub fn transfer(source: &Pubkey, destination: &Pubkey, owner: &Pubkey, amount: u
     let instruction = TokenInstruction::Transfer { amount };
 
     Instruction {
-        program_id: Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap(),
+        program_id: *token_program_id,
         accounts: account_metas,
         data: instruction.serialize(),
     }
 }
 
-/// Mint tokens to an account
+/// Mint tokens to an account (defaults to the SPL Token program)
 pub fn mint_to(
     mint: &Pubkey,
     destination: &Pubkey,
     authority: &Pubkey,
     amount: u64,
+) -> Instruction {
+    mint_to_with_program_id(
+        mint,
+        destination,
+        authority,
+        amount,
+        &default_token_program_id(),
+    )
+}
+
+/// Mint tokens to an account using the provided token program
+pub fn mint_to_with_program_id(
+    mint: &Pubkey,
+    destination: &Pubkey,
+    authority: &Pubkey,
+    amount: u64,
+    token_program_id: &Pubkey,
 ) -> Instruction {
     let account_metas = vec![
         AccountMeta {
@@ -374,14 +439,31 @@ pub fn mint_to(
     let instruction = TokenInstruction::MintTo { amount };
 
     Instruction {
-        program_id: Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap(),
+        program_id: *token_program_id,
         accounts: account_metas,
         data: instruction.serialize(),
     }
 }
 
-/// Burn tokens from an account
+/// Burn tokens from an account (defaults to the SPL Token program)
 pub fn burn(account: &Pubkey, mint: &Pubkey, authority: &Pubkey, amount: u64) -> Instruction {
+    burn_with_program_id(
+        account,
+        mint,
+        authority,
+        amount,
+        &default_token_program_id(),
+    )
+}
+
+/// Burn tokens from an account using the provided token program
+pub fn burn_with_program_id(
+    account: &Pubkey,
+    mint: &Pubkey,
+    authority: &Pubkey,
+    amount: u64,
+    token_program_id: &Pubkey,
+) -> Instruction {
     let account_metas = vec![
         AccountMeta {
             pubkey: *account,
@@ -403,14 +485,24 @@ pub fn burn(account: &Pubkey, mint: &Pubkey, authority: &Pubkey, amount: u64) ->
     let instruction = TokenInstruction::Burn { amount };
 
     Instruction {
-        program_id: Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap(),
+        program_id: *token_program_id,
         accounts: account_metas,
         data: instruction.serialize(),
     }
 }
 
-/// Close a token account
+/// Close a token account (defaults to the SPL Token program)
 pub fn close_account(account: &Pubkey, destination: &Pubkey, owner: &Pubkey) -> Instruction {
+    close_account_with_program_id(account, destination, owner, &default_token_program_id())
+}
+
+/// Close a token account using the provided token program
+pub fn close_account_with_program_id(
+    account: &Pubkey,
+    destination: &Pubkey,
+    owner: &Pubkey,
+    token_program_id: &Pubkey,
+) -> Instruction {
     let account_metas = vec![
         AccountMeta {
             pubkey: *account,
@@ -432,13 +524,13 @@ pub fn close_account(account: &Pubkey, destination: &Pubkey, owner: &Pubkey) -> 
     let instruction = TokenInstruction::CloseAccount;
 
     Instruction {
-        program_id: Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap(),
+        program_id: *token_program_id,
         accounts: account_metas,
         data: instruction.serialize(),
     }
 }
 
-/// Transfer tokens, asserting the token mint and decimals
+/// Transfer tokens, asserting the token mint and decimals (defaults to the SPL Token program)
 pub fn transfer_checked(
     source: &Pubkey,
     mint: &Pubkey,
@@ -446,6 +538,27 @@ pub fn transfer_checked(
     owner: &Pubkey,
     amount: u64,
     decimals: u8,
+) -> Instruction {
+    transfer_checked_with_program_id(
+        source,
+        mint,
+        destination,
+        owner,
+        amount,
+        decimals,
+        &default_token_program_id(),
+    )
+}
+
+/// Transfer tokens, asserting the token mint and decimals, using the provided token program
+pub fn transfer_checked_with_program_id(
+    source: &Pubkey,
+    mint: &Pubkey,
+    destination: &Pubkey,
+    owner: &Pubkey,
+    amount: u64,
+    decimals: u8,
+    token_program_id: &Pubkey,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta {
@@ -473,19 +586,38 @@ pub fn transfer_checked(
     let data = TokenInstruction::TransferChecked { amount, decimals }.serialize();
 
     Instruction {
-        program_id: Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap(),
+        program_id: *token_program_id,
         accounts,
         data,
     }
 }
 
-/// Mint new tokens to an account, asserting the token mint and decimals
+/// Mint new tokens to an account, asserting the token mint and decimals (defaults to the SPL Token program)
 pub fn mint_to_checked(
     mint: &Pubkey,
     destination: &Pubkey,
     authority: &Pubkey,
     amount: u64,
     decimals: u8,
+) -> Instruction {
+    mint_to_checked_with_program_id(
+        mint,
+        destination,
+        authority,
+        amount,
+        decimals,
+        &default_token_program_id(),
+    )
+}
+
+/// Mint new tokens to an account, asserting the token mint and decimals, using the provided token program
+pub fn mint_to_checked_with_program_id(
+    mint: &Pubkey,
+    destination: &Pubkey,
+    authority: &Pubkey,
+    amount: u64,
+    decimals: u8,
+    token_program_id: &Pubkey,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta {
@@ -508,19 +640,38 @@ pub fn mint_to_checked(
     let data = TokenInstruction::MintToChecked { amount, decimals }.serialize();
 
     Instruction {
-        program_id: Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap(),
+        program_id: *token_program_id,
         accounts,
         data,
     }
 }
 
-/// Burn tokens from an account, asserting the token mint and decimals
+/// Burn tokens from an account, asserting the token mint and decimals (defaults to the SPL Token program)
 pub fn burn_checked(
     account: &Pubkey,
     mint: &Pubkey,
     authority: &Pubkey,
     amount: u64,
     decimals: u8,
+) -> Instruction {
+    burn_checked_with_program_id(
+        account,
+        mint,
+        authority,
+        amount,
+        decimals,
+        &default_token_program_id(),
+    )
+}
+
+/// Burn tokens from an account, asserting the token mint and decimals, using the provided token program
+pub fn burn_checked_with_program_id(
+    account: &Pubkey,
+    mint: &Pubkey,
+    authority: &Pubkey,
+    amount: u64,
+    decimals: u8,
+    token_program_id: &Pubkey,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta {
@@ -543,14 +694,19 @@ pub fn burn_checked(
     let data = TokenInstruction::BurnChecked { amount, decimals }.serialize();
 
     Instruction {
-        program_id: Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap(),
+        program_id: *token_program_id,
         accounts,
         data,
     }
 }
 
-/// Sync native instruction
+/// Sync native instruction (defaults to the SPL Token program)
 pub fn sync_native(account: &Pubkey) -> Instruction {
+    sync_native_with_program_id(account, &default_token_program_id())
+}
+
+/// Sync native instruction using the provided token program
+pub fn sync_native_with_program_id(account: &Pubkey, token_program_id: &Pubkey) -> Instruction {
     let accounts = vec![AccountMeta {
         pubkey: *account,
         is_signer: false,
@@ -560,7 +716,7 @@ pub fn sync_native(account: &Pubkey) -> Instruction {
     let data = TokenInstruction::SyncNative.serialize();
 
     Instruction {
-        program_id: Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap(),
+        program_id: *token_program_id,
         accounts,
         data,
     }
@@ -570,6 +726,7 @@ pub fn sync_native(account: &Pubkey) -> Instruction {
 mod tests {
     use super::*;
     use crate::Pubkey;
+    use crate::instructions::program_ids::TOKEN_2022_PROGRAM_ID;
 
     // Use the same public keys as in the JavaScript test file
     fn mint_pubkey() -> Pubkey {
@@ -616,6 +773,12 @@ mod tests {
             data
         };
         assert_eq!(instruction.data, expected_data);
+
+        let token_2022_program = Pubkey::from_base58(TOKEN_2022_PROGRAM_ID).unwrap();
+        let instruction =
+            transfer_with_program_id(&source, &destination, &owner, amount, &token_2022_program);
+        assert_eq!(instruction.program_id, token_2022_program);
+        assert_eq!(instruction.data, expected_data);
     }
 
     #[test]
@@ -651,6 +814,19 @@ mod tests {
             data
         };
         assert_eq!(instruction.data, expected_data);
+
+        let token_2022_program = Pubkey::from_base58(TOKEN_2022_PROGRAM_ID).unwrap();
+        let instruction = transfer_checked_with_program_id(
+            &source,
+            &mint,
+            &destination,
+            &owner,
+            amount,
+            decimals,
+            &token_2022_program,
+        );
+        assert_eq!(instruction.program_id, token_2022_program);
+        assert_eq!(instruction.data, expected_data);
     }
 
     #[test]
@@ -682,6 +858,18 @@ mod tests {
             data.push(decimals);
             data
         };
+        assert_eq!(instruction.data, expected_data);
+
+        let token_2022_program = Pubkey::from_base58(TOKEN_2022_PROGRAM_ID).unwrap();
+        let instruction = mint_to_checked_with_program_id(
+            &mint,
+            &token,
+            &mint_authority,
+            amount,
+            decimals,
+            &token_2022_program,
+        );
+        assert_eq!(instruction.program_id, token_2022_program);
         assert_eq!(instruction.data, expected_data);
     }
 
@@ -715,6 +903,18 @@ mod tests {
             data
         };
         assert_eq!(instruction.data, expected_data);
+
+        let token_2022_program = Pubkey::from_base58(TOKEN_2022_PROGRAM_ID).unwrap();
+        let instruction = burn_checked_with_program_id(
+            &account,
+            &mint,
+            &authority,
+            amount,
+            decimals,
+            &token_2022_program,
+        );
+        assert_eq!(instruction.program_id, token_2022_program);
+        assert_eq!(instruction.data, expected_data);
     }
 
     #[test]
@@ -733,5 +933,174 @@ mod tests {
 
         // Check data - should be [17] (sync native instruction)
         assert_eq!(instruction.data, vec![17]);
+
+        let token_2022_program = Pubkey::from_base58(TOKEN_2022_PROGRAM_ID).unwrap();
+        let instruction = sync_native_with_program_id(&account, &token_2022_program);
+        assert_eq!(instruction.program_id, token_2022_program);
+        assert_eq!(instruction.accounts.len(), 1);
+        assert_eq!(instruction.accounts[0].pubkey, account);
+        assert!(instruction.accounts[0].is_writable);
+        assert_eq!(instruction.data, vec![17]);
+    }
+
+    #[test]
+    fn test_initialize_mint() {
+        let mint = mint_pubkey();
+        let mint_authority = authority_pubkey();
+        let decimals = 9u8;
+        let rent = Pubkey::from_base58(SYSVAR_RENT_ID).unwrap();
+
+        let instruction = initialize_mint(&mint, &mint_authority, None, decimals);
+        assert_eq!(
+            instruction.program_id,
+            Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap()
+        );
+        assert_eq!(instruction.accounts.len(), 2);
+        assert_eq!(instruction.accounts[0].pubkey, mint);
+        assert!(instruction.accounts[0].is_writable);
+        assert_eq!(instruction.accounts[1].pubkey, rent);
+
+        let expected_data = {
+            let mut data = vec![0, decimals];
+            data.extend_from_slice(mint_authority.as_bytes());
+            data.push(0); // no freeze authority
+            data
+        };
+        assert_eq!(instruction.data, expected_data);
+
+        let token_2022_program = Pubkey::from_base58(TOKEN_2022_PROGRAM_ID).unwrap();
+        let instruction = initialize_mint_with_program_id(
+            &mint,
+            &mint_authority,
+            None,
+            decimals,
+            &token_2022_program,
+        );
+        assert_eq!(instruction.program_id, token_2022_program);
+        assert_eq!(instruction.data, expected_data);
+    }
+
+    #[test]
+    fn test_initialize_account() {
+        let account = token_pubkey();
+        let mint = mint_pubkey();
+        let owner = authority_pubkey();
+
+        let instruction = initialize_account(&account, &mint, &owner);
+        assert_eq!(
+            instruction.program_id,
+            Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap()
+        );
+        assert_eq!(instruction.accounts.len(), 4);
+        assert_eq!(instruction.accounts[0].pubkey, account);
+        assert!(instruction.accounts[0].is_writable);
+        assert_eq!(instruction.accounts[1].pubkey, mint);
+        assert_eq!(instruction.accounts[2].pubkey, owner);
+        assert_eq!(
+            instruction.accounts[3].pubkey,
+            Pubkey::from_base58(SYSVAR_RENT_ID).unwrap()
+        );
+        assert_eq!(instruction.data, vec![1]);
+
+        let token_2022_program = Pubkey::from_base58(TOKEN_2022_PROGRAM_ID).unwrap();
+        let instruction =
+            initialize_account_with_program_id(&account, &mint, &owner, &token_2022_program);
+        assert_eq!(instruction.program_id, token_2022_program);
+        assert_eq!(instruction.data, vec![1]);
+    }
+
+    #[test]
+    fn test_mint_to() {
+        let mint = mint_pubkey();
+        let destination = token_pubkey();
+        let authority = authority_pubkey();
+        let amount = 123u64;
+
+        let instruction = mint_to(&mint, &destination, &authority, amount);
+        assert_eq!(
+            instruction.program_id,
+            Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap()
+        );
+        assert_eq!(instruction.accounts.len(), 3);
+        assert_eq!(instruction.accounts[0].pubkey, mint);
+        assert!(instruction.accounts[0].is_writable);
+        assert_eq!(instruction.accounts[1].pubkey, destination);
+        assert!(instruction.accounts[1].is_writable);
+        assert_eq!(instruction.accounts[2].pubkey, authority);
+        assert!(instruction.accounts[2].is_signer);
+
+        let expected_data = {
+            let mut data = vec![7];
+            data.extend_from_slice(&amount.to_le_bytes());
+            data
+        };
+        assert_eq!(instruction.data, expected_data);
+
+        let token_2022_program = Pubkey::from_base58(TOKEN_2022_PROGRAM_ID).unwrap();
+        let instruction =
+            mint_to_with_program_id(&mint, &destination, &authority, amount, &token_2022_program);
+        assert_eq!(instruction.program_id, token_2022_program);
+        assert_eq!(instruction.data, expected_data);
+    }
+
+    #[test]
+    fn test_burn() {
+        let account = token_pubkey();
+        let mint = mint_pubkey();
+        let authority = authority_pubkey();
+        let amount = 123u64;
+
+        let instruction = burn(&account, &mint, &authority, amount);
+        assert_eq!(
+            instruction.program_id,
+            Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap()
+        );
+        assert_eq!(instruction.accounts.len(), 3);
+        assert_eq!(instruction.accounts[0].pubkey, account);
+        assert!(instruction.accounts[0].is_writable);
+        assert_eq!(instruction.accounts[1].pubkey, mint);
+        assert!(instruction.accounts[1].is_writable);
+        assert_eq!(instruction.accounts[2].pubkey, authority);
+        assert!(instruction.accounts[2].is_signer);
+
+        let expected_data = {
+            let mut data = vec![8];
+            data.extend_from_slice(&amount.to_le_bytes());
+            data
+        };
+        assert_eq!(instruction.data, expected_data);
+
+        let token_2022_program = Pubkey::from_base58(TOKEN_2022_PROGRAM_ID).unwrap();
+        let instruction =
+            burn_with_program_id(&account, &mint, &authority, amount, &token_2022_program);
+        assert_eq!(instruction.program_id, token_2022_program);
+        assert_eq!(instruction.data, expected_data);
+    }
+
+    #[test]
+    fn test_close_account() {
+        let account = token_pubkey();
+        let destination = payer_pubkey();
+        let owner = authority_pubkey();
+
+        let instruction = close_account(&account, &destination, &owner);
+        assert_eq!(
+            instruction.program_id,
+            Pubkey::from_base58(TOKEN_PROGRAM_ID).unwrap()
+        );
+        assert_eq!(instruction.accounts.len(), 3);
+        assert_eq!(instruction.accounts[0].pubkey, account);
+        assert!(instruction.accounts[0].is_writable);
+        assert_eq!(instruction.accounts[1].pubkey, destination);
+        assert!(instruction.accounts[1].is_writable);
+        assert_eq!(instruction.accounts[2].pubkey, owner);
+        assert!(instruction.accounts[2].is_signer);
+        assert_eq!(instruction.data, vec![9]);
+
+        let token_2022_program = Pubkey::from_base58(TOKEN_2022_PROGRAM_ID).unwrap();
+        let instruction =
+            close_account_with_program_id(&account, &destination, &owner, &token_2022_program);
+        assert_eq!(instruction.program_id, token_2022_program);
+        assert_eq!(instruction.data, vec![9]);
     }
 }


### PR DESCRIPTION
## Summary

Surface a few primitives that downstream callers currently have to reimplement against the raw `Instruction` API.

- **Token-2022 program-id variants** for every SPL Token instruction helper (`initialize_mint`, `initialize_account`, `mint_to`, `burn`, `close_account`, `transfer`, `transfer_checked`, `mint_to_checked`, `burn_checked`, `sync_native`). Existing helpers delegate to the new `_with_program_id` forms, so there's no caller-visible change for SPL Token users.
- **Associated Token Account additions**: `create_associated_token_account_with_program_id`, `create_associated_token_account_idempotent` (+ an explicit-address form), and `get_associated_token_address_with_program_id`.
- **Anchor module** with `global_discriminator`, `account_discriminator`, and `event_discriminator` (SHA256-based, 8-byte) for building instructions and parsing account/event payloads.
- **Shared `SYSVAR_RENT_ID`** in `program_ids` so the rent sysvar no longer appears as inline string literals across modules.
- Small clippy fix in the v0 message builder (`explicit_counter_loop`) — split into its own commit.

## Test plan

- [x] `cargo test` — 63 tests pass (up from 54). New coverage:
  - Token-2022 assertions on every new `_with_program_id` helper
  - First-time coverage for `initialize_mint`, `initialize_account`, `mint_to`, `burn`, `close_account` (both default and program-id forms)
  - `create_associated_token_account_with_program_id` and `create_associated_token_account_idempotent` (+ explicit-address)
  - Anchor discriminators for all three namespaces, plus a differentiation test that the same name yields distinct discriminators across `global:`/`account:`/`event:`
- [x] `just lint-fix` clean
- [x] `cargo fmt` clean